### PR TITLE
Fix Blaze Health Check and Remove Wait Script

### DIFF
--- a/.github/workflows/ci-blaze.yml
+++ b/.github/workflows/ci-blaze.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches:
+    - main
+    - develop
 
 jobs:
   test:
@@ -26,20 +28,7 @@ jobs:
       run: ./scripts/terminology/get-mii-terminology.sh install
     
     - name: Start services with Blaze profile (CI mode - SNOMED disabled)
-      run: docker compose --profile blaze -f docker-compose.yml -f .github/configs/docker-compose.ci.yml up -d
-    
-    - name: Wait for Blaze to be ready
-      run: |
-        echo "Waiting for Blaze to start..."
-        for i in {1..30}; do
-          if curl -f http://localhost:8082/fhir/metadata >/dev/null 2>&1; then
-            echo "Blaze is ready!"
-            break
-          fi
-          echo "Attempt $i/30: Blaze not ready yet..."
-          sleep 2
-        done
-        curl -f http://localhost:8082/fhir/metadata || exit 1
+      run: docker compose --profile blaze -f docker-compose.yml -f .github/configs/docker-compose.ci.yml up --wait
     
     - name: Upload MII terminology to Blaze
       run: ./scripts/terminology/upload-terminology.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,10 +73,11 @@ services:
     networks:
       - fhir-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: [ "CMD", "wget", "--spider", "http://localhost:8080/health" ]
       interval: 10s
-      timeout: 3s
-      retries: 3
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
     profiles: ["blaze"]
 


### PR DESCRIPTION
Blaze will remove the curl command for health checks in the future. So I switched to wget. Also used --wait instead of -d at docker compose up and removed the Blaze wait script. Kept the Validator wait script, because it has no health check.