### PR TITLE
For default docker compose profile use environment variable COMPOSE_PROFILES in existing config file .env instead of additional cli parameter --profile

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,5 +1,11 @@
 # --- Base Configuration ---
 
+# Setup uses Docker Compose profiles to support different terminology server configurations
+# Blaze Profile (Default - Local Development): Local Blaze terminology server with LOINC and SNOMED CT. Direct HTTP connection (no authentication required).
+COMPOSE_PROFILES=blaze
+# Ontoserver Profile (MII Production Server): Connects to external MII Service Unit Terminology Server via nginx proxy. Requires client certificates for authentication.
+# COMPOSE_PROFILES=ontoserver
+
 # Adjust memory allocation as needed
 JAVA_OPTS="-Xmx16g"
 

--- a/.github/workflows/ci-blaze.yml
+++ b/.github/workflows/ci-blaze.yml
@@ -36,8 +36,8 @@ jobs:
     - name: Prepare environment
       run: cp .env.default .env
 
-    - name: Start services with Blaze profile (CI mode)
-      run: docker compose --profile blaze -f docker-compose.yml -f .github/configs/docker-compose.ci.yml up --wait
+    - name: Start services (CI mode) with Blaze profile (which is set by default in .env by step before)
+      run: docker compose -f docker-compose.yml -f .github/configs/docker-compose.ci.yml up --wait
     
     - name: Upload MII terminology to Blaze
       run: ./scripts/terminology/upload-terminology.sh
@@ -46,16 +46,16 @@ jobs:
       run: |
         echo "Waiting for validator to start..."
         for i in {1..120}; do
-          if docker compose --profile blaze logs validator 2>&1 | grep -q "FHIR Validator HTTP Service started"; then
+          if docker compose logs validator 2>&1 | grep -q "FHIR Validator HTTP Service started"; then
             echo "Validator is ready!"
             break
           fi
           echo "Attempt $i/120: not ready yet..."
           sleep 3
         done
-        if ! docker compose --profile blaze logs validator 2>&1 | grep -q "FHIR Validator HTTP Service started"; then
+        if ! docker compose logs validator 2>&1 | grep -q "FHIR Validator HTTP Service started"; then
           echo "ERROR: Validator failed to start. Logs:"
-          docker compose --profile blaze logs validator
+          docker compose logs validator
           exit 1
         fi
     
@@ -119,10 +119,10 @@ jobs:
       if: failure()
       run: |
         echo "=== Docker Compose Logs ==="
-        docker compose --profile blaze logs
+        docker compose logs
         echo "=== Container Status ==="
-        docker compose --profile blaze ps
+        docker compose ps
     
     - name: Cleanup
       if: always()
-      run: docker compose --profile blaze -f docker-compose.yml -f .github/configs/docker-compose.ci.yml down -v
+      run: docker compose -f docker-compose.yml -f .github/configs/docker-compose.ci.yml down -v

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For access to the **MII Service Unit Terminology Server** (`ontoserver.mii-terms
 
 6. **Start the services:**
    ```bash
-   docker compose --profile blaze up -d
+   docker compose up -d
    ```
    Docker Compose pulls the pre-built image from GHCR automatically and starts both services.
 
@@ -74,13 +74,13 @@ This setup uses Docker Compose profiles to support different terminology server 
 **Blaze Profile (Default - Local Development):**
 - Local Blaze terminology server with LOINC and SNOMED CT
 - Direct HTTP connection (no authentication required)
-- Start with: `docker compose --profile blaze up -d`
+- Set `COMPOSE_PROFILES` to `blaze` in `.env`
 
 **Ontoserver Profile (MII Production Server):**
 - Connects to MII Service Unit Terminology Server via nginx proxy
 - Requires client certificates for authentication
 - Validator connects to nginx via HTTP, nginx proxies HTTPS to MII Ontoserver
-- Start with: `docker compose --profile ontoserver up -d`
+- Set `COMPOSE_PROFILES` to `ontoserver` in `.env`
 
 ### Blaze Terminology Server (Default)
 
@@ -157,7 +157,7 @@ The pre-built image contains the full FHIR package cache for all default MII IGs
 If you add IGs beyond the defaults via `IG_PARAMS`, their dependencies will be resolved at startup. To ensure they are available offline, run the validator once while online to populate the cache:
 
 ```bash
-docker compose --profile blaze up -d
+docker compose up -d
 # Wait for all packages to download (check logs: docker compose logs validator)
 docker compose down
 ```
@@ -203,14 +203,10 @@ To use the **MII Service Unit Terminology Server** at `https://ontoserver.mii-te
    ```bash
    cp .env.default .env
    # Edit .env and change:
+   COMPOSE_PROFILES=ontoserver
    TX_SERVER="http://nginx/fhir"
    ```
 
-3. **Start with Ontoserver profile:**
-   ```bash
-   docker compose --profile ontoserver up -d
-   ```
-   
    The setup works as follows:
    - Validator connects to nginx via HTTP
    - Nginx proxies requests to MII Ontoserver via HTTPS
@@ -219,11 +215,10 @@ To use the **MII Service Unit Terminology Server** at `https://ontoserver.mii-te
 ### Using Other Terminology Servers
 
 **For a local server without authentication (e.g., HAPI FHIR):**
+- Set `COMPOSE_PROFILES` to `blaze` in `.env`
 - Set `TX_SERVER` to `http://your-server:port/fhir` in `.env`
-- Use the blaze profile: `docker compose --profile blaze up -d`
 
 **For other authenticated servers:**
 - Follow steps similar to MII Ontoserver setup
 - Update `nginx/nginx.conf` with correct URL and certificate paths
-- Use the ontoserver profile: `docker compose --profile ontoserver up -d`
-
+- Use the ontoserver profile by setting `COMPOSE_PROFILES` to `ontoserver` in `.env`

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -38,7 +38,7 @@ Docker Compose reads `.env` automatically. The `.env.default` file contains sens
 ## Step 4: Start Services
 
 ```bash
-docker compose --profile blaze up -d
+docker compose up -d
 ```
 
 This starts:
@@ -81,11 +81,12 @@ To develop against the MII Ontoserver instead of local Blaze:
    ```
 2. Update `.env`:
    ```
+   COMPOSE_PROFILES=ontoserver
    TX_SERVER="http://nginx/fhir"
    ```
-3. Start with the ontoserver profile:
+3. Start with this ontoserver profile:
    ```bash
-   docker compose --profile ontoserver up -d
+   docker compose up -d
    ```
 
 > [!IMPORTANT]

--- a/docs/use.md
+++ b/docs/use.md
@@ -7,15 +7,17 @@
 Start the FHIR Validator with the local Blaze terminology server:
 
 ```bash
-docker compose --profile blaze up -d
+docker compose up -d
 ```
 
-### Ontoserver Profile
+### Ontoserver Profile (Alternate)
 
-Start the FHIR Validator with the MII Ontoserver via nginx proxy (requires client certificates in `nginx/certs/`):
+Use the ontoserver profile by setting `COMPOSE_PROFILES` to `ontoserver` in `.env` before first start (else run a `docker compose down` before).
+
+After that start the FHIR Validator with the MII Ontoserver via nginx proxy (requires client certificates in `nginx/certs/`):
 
 ```bash
-docker compose --profile ontoserver up -d
+docker compose up -d
 ```
 
 ### Loading Terminology Resources into Blaze
@@ -105,7 +107,7 @@ SNOMED CT release files must still be present in `snomed-ct-release/` for Blaze 
 If you add IGs beyond the defaults via `IG_PARAMS`, their dependencies will be resolved at startup and may require internet access. To pre-cache them, run the validator once while online:
 
 ```bash
-docker compose --profile blaze up -d
+docker compose up -d
 # Wait for the validator to finish downloading packages:
 docker compose logs -f validator
 # Once ready:

--- a/nginx/certs/README.md
+++ b/nginx/certs/README.md
@@ -15,7 +15,7 @@ openssl rsa -in encrypted-key.key -out client-key.key
 
 ## How It Works
 
-When using the Ontoserver profile (`docker compose --profile ontoserver up`):
+When using the Ontoserver profile (for example by setting `COMPOSE_PROFILES` to `ontoserver` in `.env`):
 - The validator connects to nginx via **HTTP** (using the `allowHttp` feature)
 - Nginx proxies requests to MII Ontoserver via **HTTPS**
 - Client certificates are used by nginx for authentication with MII Ontoserver


### PR DESCRIPTION
Vorschlag zur Config des (default) docker compose profile in sowieso schon vorhandener Config .env statt per CLI Parameter --profile (für Admins zusätzlich zu berücksichtigender Config Ebene / separat und zusätzlich zu verwaltender/zu dokumentierender CLI Parameter).