### PR TITLE
Make FHIR base URL of the terminology server configurable in terminology upload script

### DIFF
--- a/scripts/terminology/upload-terminology.sh
+++ b/scripts/terminology/upload-terminology.sh
@@ -1,7 +1,11 @@
 #!/bin/bash -e
 
 script_dir="$(dirname "$(readlink -f "$0")")"
-base="http://localhost:8082/fhir"
+
+# FHIR base URL of the terminology server
+# Configurable by env variable TX_SERVER
+# If this env variable not set, use default http://localhost:8082/fhir
+base="${TX_SERVER:-http://localhost:8082/fhir}"
 
 upload_file() {
   local filename="$1"


### PR DESCRIPTION
Make FHIR base URL of the terminology server configurable.

So the script can be used in different settings (f.e. inside a Docker container uploading to another Docker service which is not done by localhost but by Docker hostnames or within a CI/CD pipeline where the vocabulary server will not be deployed to localhost).

Suggestion here: Make it configurable by env variable TX_SERVER (which is yet used in docker-compose.yml for URL of the same service.

