### PR TITLE
Dockerfile for provisioning of vocabulary by scripts/terminology

### DIFF
--- a/scripts/terminology/Dockerfile
+++ b/scripts/terminology/Dockerfile
@@ -1,0 +1,12 @@
+# Scripts need Node Package Manager (npm) for download of FHIR packages which are NPM format; Alternate: Debian based Node JS image
+FROM node:alpine
+
+# Need bash (not part of alpine) to run the terminology scripts
+# Upload scripts need jq and curl
+RUN apk update && apk add --no-cache bash jq curl
+
+WORKDIR /app
+
+COPY . .
+
+ENTRYPOINT ["bash", "/app/get-and-upload-terminology.sh"]

--- a/scripts/terminology/get-and-upload-terminology.sh
+++ b/scripts/terminology/get-and-upload-terminology.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+#
+# This script (get-and-upload-terminology.sh) is used as ENTRYPOINT in Dockerfile to call all other scripts
+#
+
+echo "Downloading NPM Packages"
+./get-mii-terminology.sh install
+
+echo "Uploading terminology to local FHIR Server"
+./upload-terminology.sh


### PR DESCRIPTION
Increased automation of validator setup in some use cases:

Provisioning of vocabulary by scripts/terminology is possible by Docker.
So admins/users dont have to install/manage additional dependencies (especially NPM / Node JS) on local machine or VM to be able to run the terminology download and upload.

Increased security:

By using Docker container for provisioning of terminology, users dont have to run external scripts from Github repo (bash scripts) and install external NPM packagess on local OS/Filesystem/VM.