### PR TITLE
feat: dedicated directory for package cache

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -9,6 +9,18 @@ COMPOSE_PROFILES=blaze
 # Adjust memory allocation as needed
 JAVA_OPTS="-Xmx16g"
 
+# FHIR package cache directory.
+# Defaults to /root inside the image. Override to a writable volume path
+# (e.g. /var/lib/fhir) when running with a non-root user or immutable root filesystem.
+FHIR_HOME="/root"
+
+# Seed the writable FHIR package cache from baked-in defaults at startup.
+# When true (default), the entrypoint copies the pre-built MII IG cache into
+# $FHIR_HOME/.fhir/packages on first start (skipped if already populated).
+# If $FHIR_HOME is not writable, the baked-in read-only cache is used instead.
+# Set to false to start with a blank cache (validator downloads packages at runtime).
+FHIR_CACHE_SEED="true"
+
 # FHIR specification version (default: 4.0 / R4)
 # FHIR_VERSION="4.0"
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Configuration is split into two tiers:
 
 **Built-in defaults in `docker-compose.yml` (override in `.env` only if needed):**
 - `FHIR_VERSION` - FHIR version (default: `4.0`)
+- `FHIR_HOME` - FHIR package cache home directory (default: `/root`)
+- `FHIR_CACHE_SEED` - Seed writable cache from baked-in defaults at startup (default: `true`)
 - `TX_SERVER` - Terminology server URL (default: `http://blaze-terminology:8080/fhir` for blaze profile, `http://nginx/fhir` for ontoserver profile)
 - `TX_CACHE_DIR` - Terminology cache directory (default: `/tmp/tx-cache`)
 - `TX_LOG` - Terminology request log path (default: `/tmp/tx-cache/tx.log`)
@@ -162,7 +164,7 @@ docker compose up -d
 docker compose down
 ```
 
-The `fhir-package-cache` Docker volume persists the cache across container restarts.
+The `fhir-package-cache` Docker volume persists the cache at `$FHIR_HOME/.fhir/packages` across container restarts. By default (`FHIR_CACHE_SEED=true`), the baked-in MII IG cache is seeded into an empty volume on first start, enabling offline operation immediately. If the volume is read-only, the validator falls back to the baked-in cache automatically.
 
 To load IGs from the `igs/` directory:
 ```bash
@@ -170,6 +172,73 @@ IG_PARAMS="-ig /igs/your-package-2026.0.0.tgz -ig /igs/another-package.tgz"
 ```
 
 **Note:** A terminology service (Blaze) is still required for offline terminology validation (CodeSystem, ValueSet bindings, code validation). SNOMED CT release files must be provided locally — see [snomed-ct-release/README.md](snomed-ct-release/README.md).
+
+## Kubernetes / Non-Root Deployment
+
+The image supports deployment under Kubernetes with `runAsNonRoot: true` and `readOnlyRootFilesystem: true`. The FHIR package cache location and seeding behavior are controlled by `FHIR_HOME` and `FHIR_CACHE_SEED`.
+
+### Cache Modes
+
+The entrypoint supports three modes based on `FHIR_CACHE_SEED` and mount writability:
+
+1. **Seeded cache** (default, `FHIR_CACHE_SEED=true`): The baked-in MII IG cache is copied into `$FHIR_HOME/.fhir/packages` on first start if the target is empty and writable. If the target is not writable, the validator falls back to the baked-in read-only cache automatically.
+
+2. **Read-only fallback** (automatic with `FHIR_CACHE_SEED=true`): When the package cache mount is read-only, the validator uses the baked-in cache directly. No write access to the package cache is required when no packages are downloaded at runtime.
+
+3. **Blank cache** (`FHIR_CACHE_SEED=false`): The validator starts with an empty cache and downloads packages at runtime. Requires a writable `FHIR_HOME` mount.
+
+### Required Configuration
+
+For Kubernetes with `readOnlyRootFilesystem: true`:
+- Set `FHIR_HOME` to a writable mount path (e.g., `/var/lib/fhir`) if you need runtime package downloads
+- Mount a writable volume (emptyDir or PVC) at `$FHIR_HOME/.fhir/packages` for the package cache
+- Mount a writable volume at `/tmp` for terminology cache and `fhir-settings.json`
+- The terminology cache (`TX_CACHE_DIR`, default `/tmp/tx-cache`) must be writable
+- Set `TX_LOG=""` to disable terminology logging (reduces write surface)
+
+With `FHIR_CACHE_SEED=true` (default), the package cache may be mounted **read-only** when no runtime package downloads are needed — the entrypoint automatically falls back to the baked-in cache.
+
+### Example: Offline-First with Read-Only Package Cache
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+env:
+  - name: FHIR_HOME
+    value: "/var/lib/fhir"
+  - name: FHIR_CACHE_SEED
+    value: "true"
+volumeMounts:
+  - name: fhir-cache
+    mountPath: /var/lib/fhir/.fhir/packages
+    readOnly: true  # Read-only is fine with FHIR_CACHE_SEED=true
+  - name: tx-cache
+    mountPath: /tmp/tx-cache
+  - name: tmp
+    mountPath: /tmp
+volumes:
+  - name: fhir-cache
+    emptyDir: { }
+  - name: tx-cache
+    emptyDir: { }
+  - name: tmp
+    emptyDir: { }
+```
+
+### Example: Blank Cache with Runtime Downloads
+
+```yaml
+env:
+  - name: FHIR_HOME
+    value: "/var/lib/fhir"
+  - name: FHIR_CACHE_SEED
+    value: "false"
+volumeMounts:
+  - name: fhir-cache
+    mountPath: /var/lib/fhir/.fhir/packages  # Must be writable
+```
 
 ## Alternative: MII Ontoserver Setup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     environment:
       - JAVA_OPTS=${JAVA_OPTS}
       - FHIR_VERSION=${FHIR_VERSION:-4.0}
+      - FHIR_HOME=${FHIR_HOME:-/root}
+      - FHIR_CACHE_SEED=${FHIR_CACHE_SEED:-true}
       - TX_SERVER=${TX_SERVER:-http://blaze-terminology:8080/fhir}
       - TX_SERVER_USERNAME=${TX_SERVER_USERNAME:-}
       - TX_SERVER_PASSWORD=${TX_SERVER_PASSWORD:-}
@@ -20,7 +22,7 @@ services:
       - IG_PARAMS=${IG_PARAMS}
     volumes:
       - ./igs:/igs:ro
-      - fhir-package-cache:/root/.fhir/packages
+      - fhir-package-cache:${FHIR_HOME}/.fhir/packages
       - tx-cache:${TX_CACHE_DIR:-/tmp/tx-cache}
       # Optional: override the built-in advisor configuration
       # - ./validator/advisor.json:/app/validator/advisor.json:ro
@@ -45,13 +47,15 @@ services:
     environment:
       - JAVA_OPTS=${JAVA_OPTS}
       - FHIR_VERSION=${FHIR_VERSION:-4.0}
+      - FHIR_HOME=${FHIR_HOME:-/root}
+      - FHIR_CACHE_SEED=${FHIR_CACHE_SEED:-true}
       - TX_SERVER=${TX_SERVER:-http://nginx/fhir}
       - TX_CACHE_DIR=${TX_CACHE_DIR:-/tmp/tx-cache}
       - TX_LOG=${TX_LOG:-/tmp/tx-cache/tx.log}
       - IG_PARAMS=${IG_PARAMS}
     volumes:
       - ./igs:/igs:ro
-      - fhir-package-cache:/root/.fhir/packages
+      - fhir-package-cache:${FHIR_HOME}/.fhir/packages
       - tx-cache:${TX_CACHE_DIR:-/tmp/tx-cache}
       - ./nginx/certs:/certs:ro
       # Optional: override the built-in advisor configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - IG_PARAMS=${IG_PARAMS}
     volumes:
       - ./igs:/igs:ro
-      - fhir-package-cache:${FHIR_HOME}/.fhir/packages
+      - fhir-package-cache:${FHIR_HOME:-/root}/.fhir/packages
       - tx-cache:${TX_CACHE_DIR:-/tmp/tx-cache}
       # Optional: override the built-in advisor configuration
       # - ./validator/advisor.json:/app/validator/advisor.json:ro
@@ -55,7 +55,7 @@ services:
       - IG_PARAMS=${IG_PARAMS}
     volumes:
       - ./igs:/igs:ro
-      - fhir-package-cache:${FHIR_HOME}/.fhir/packages
+      - fhir-package-cache:${FHIR_HOME:-/root}/.fhir/packages
       - tx-cache:${TX_CACHE_DIR:-/tmp/tx-cache}
       - ./nginx/certs:/certs:ro
       # Optional: override the built-in advisor configuration

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -40,7 +40,8 @@ ARG IG_LIST="-ig de.basisprofil.r4#1.5.4 \
 "
 
 # Pre-build FHIR package cache with MII IGs (downloads packages during build)
-RUN java -Xmx4g -jar validator_cli.jar ${IG_LIST} -version 4.0
+RUN java -Xmx4g -Duser.home="/app/fhir-cache" -jar validator_cli.jar ${IG_LIST} -version 4.0
+RUN chmod -R a+rX /app/fhir-cache
 
 # Create directory for IGs
 RUN mkdir -p /igs

--- a/validator/docker-entrypoint.sh
+++ b/validator/docker-entrypoint.sh
@@ -2,6 +2,26 @@
 
 set -eu
 
+FHIR_HOME="${FHIR_HOME:-/root}"
+DEFAULT_CACHE="/app/fhir-cache"
+CACHE_HOME="${FHIR_HOME}"
+
+if [ "${FHIR_CACHE_SEED:-true}" = "true" ]; then
+  pkgs="${FHIR_HOME}/.fhir/packages"
+  if [ ! -e "$pkgs" ] || [ -z "$(ls -A "$pkgs" 2>/dev/null)" ]; then
+    if mkdir -p "$pkgs" 2>/dev/null && cp -r /app/fhir-cache/.fhir/packages/. "$pkgs/" 2>/dev/null; then
+      echo "Seeded FHIR package cache into ${pkgs}"
+    else
+      echo "FHIR_HOME not writable; using baked-in read-only cache at ${DEFAULT_CACHE}"
+      CACHE_HOME="${DEFAULT_CACHE}"
+    fi
+  else
+    echo "FHIR cache at ${pkgs} already populated; skipping seed"
+  fi
+fi
+
+export JAVA_TOOL_OPTIONS="-Duser.home=${CACHE_HOME} ${JAVA_TOOL_OPTIONS:-}"
+
 # Validate credential environment variables
 if { [ -n "${TX_SERVER_USERNAME:-}" ] && [ -z "${TX_SERVER_PASSWORD:-}" ]; } || \
    { [ -z "${TX_SERVER_USERNAME:-}" ] && [ -n "${TX_SERVER_PASSWORD:-}" ]; }; then


### PR DESCRIPTION
The current container implementation forces the Java FHIR validator package cache into `/root/.fhir/packages/`. This approach creates significant hurdles when running the container under production-grade security constraints. 

To resolve this, this PR separates the build-time staging cache from the execution-time runtime directory based on the following engineering decisions:

* **Eliminating `/root/` Dependencies for Cache Creation:** Under strict non-root runtimes (e.g., custom UIDs in Kubernetes clusters), the parent `/root/` directory is entirely inaccessible (`drwx------`) to the unprivileged process. Moving the static, pre-built build artifact staging cache out of `/root` prevents fatal `Permission Denied` errors during startup script traversal.
* **Support for Immutable Filesystems (`readOnlyRootFilesystem`):** In modern cloud environments with write-locked root file systems, the validator cannot perform essential package metadata updates or handle transient caches natively within the image layers.
* **Dynamic Cache Relocation over Empty Volumes:** When an external writable volume is mounted to the container to alleviate filesystem locks, it inadvertently masks any pre-baked FHIR packages bundled during image building. Using a conditional copying step at startup ensures the writable target volume is properly hydrated with the required packages before execution begins.
* **Explicit JVM Targeting via `JAVA_TOOL_OPTIONS`:** Passing `-Duser.home` transparently overrides the fallback `System.getProperty("user.home")` check within `validator_cli.jar`. This forces the validator to reliably find and interact with its package definitions inside the designated, writable runtime directory regardless of arbitrary runtime UIDs.