### PR TITLE
update validate image

### DIFF
--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -11,10 +11,10 @@ LABEL org.opencontainers.image.url="https://medizininformatik-initiative.github.
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.source="https://github.com/medizininformatik-initiative/mii-fhir-validator"
 
+USER 10001:10001
+
 # Create working directory and directory for IGs
 WORKDIR /app
-
-USER 10001:10001
 
 # Copy license files
 COPY LICENSE /licenses/LICENSE

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -3,7 +3,7 @@ ARG VALIDATOR_VERSION=6.9.11
 RUN wget -O /validator_cli.jar \
   https://github.com/hapifhir/org.hl7.fhir.core/releases/download/${VALIDATOR_VERSION}/validator_cli.jar
 
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:25-jre
 
 LABEL org.opencontainers.image.title="MII FHIR Validator"
 LABEL org.opencontainers.image.description="A FHIR validation service pre-configured for MII Implementation Guides"
@@ -42,7 +42,7 @@ ARG IG_LIST="-ig de.basisprofil.r4#1.5.4 \
   -ig de.medizininformatikinitiative.kerndatensatz.mtb#2026.0.0 \
   -ig de.medizininformatikinitiative.kerndatensatz.pros#2026.4.1 \
   -ig de.medizininformatikinitiative.kerndatensatz.seltene#2026.0.1 \
-"
+  "
 
 # Pre-build FHIR package cache with MII IGs (downloads packages during build)
 RUN java -Xmx4g -Duser.home="/app/fhir-cache" -jar validator_cli.jar ${IG_LIST} -version 4.0 -tx n/a

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -11,15 +11,21 @@ LABEL org.opencontainers.image.url="https://medizininformatik-initiative.github.
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.source="https://github.com/medizininformatik-initiative/mii-fhir-validator"
 
-# Create working directory
+# Create working directory and directory for IGs
 WORKDIR /app
+
+USER 10001:10001
 
 # Copy license files
 COPY LICENSE /licenses/LICENSE
 COPY THIRD_PARTY_NOTICES.md /licenses/THIRD_PARTY_NOTICES.md
 
 # Copy validator JAR
-COPY --from=fetch-validator /validator_cli.jar /app/validator_cli.jar
+COPY --from=fetch-validator /tmp/validator_cli.jar /app/validator_cli.jar
+
+# Für Builds hinter einem Proxy, z.B.:
+#   --build-arg JAVA_TOOL_OPTIONS="-Dhttps.proxyHost=proxy.example -Dhttps.proxyPort=8080"
+ARG JAVA_TOOL_OPTIONS=""
 
 # IG list as build argument (keep in sync with IG_PARAMS in .env.default)
 ARG IG_LIST="-ig de.basisprofil.r4#1.5.4 \
@@ -42,8 +48,7 @@ ARG IG_LIST="-ig de.basisprofil.r4#1.5.4 \
   "
 
 # Pre-build FHIR package cache with MII IGs (downloads packages during build)
-RUN java -Xmx4g -Duser.home="/app/fhir-cache" -jar validator_cli.jar ${IG_LIST} -version 4.0 -tx n/a \
-  && rm -rf /app/fhir-cache/.fhir/packages/hl7.fhir.r4.examples* \
+RUN java -Xmx4g -Duser.home="/app/fhir-cache" -jar validator_cli.jar ${IG_LIST} -version 4.0 -tx n/a -proxy "10.10.6.12:8080" \
   && chmod -R a+rX /app/fhir-cache
 
 # Create directory for IGs
@@ -59,6 +64,5 @@ ENV DEFAULT_IG_PARAMS="${IG_LIST}"
 COPY validator/advisor.json /app/validator/advisor.json
 
 # Entrypoint script: generates fhir-settings.json at runtime if TX_SERVER uses HTTP
-COPY validator/docker-entrypoint.sh /app/docker-entrypoint.sh
-RUN chmod +x /app/docker-entrypoint.sh
+COPY --chmod=0555 validator/docker-entrypoint.sh /app/docker-entrypoint.sh
 ENTRYPOINT ["/bin/sh", "/app/docker-entrypoint.sh"]

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -3,16 +3,13 @@ ARG VALIDATOR_VERSION=6.9.11
 RUN wget -O /validator_cli.jar \
   https://github.com/hapifhir/org.hl7.fhir.core/releases/download/${VALIDATOR_VERSION}/validator_cli.jar
 
-FROM eclipse-temurin:25-jre
+FROM eclipse-temurin:25.0.3_9-jre-ubi10-minimal
 
 LABEL org.opencontainers.image.title="MII FHIR Validator"
 LABEL org.opencontainers.image.description="A FHIR validation service pre-configured for MII Implementation Guides"
 LABEL org.opencontainers.image.url="https://medizininformatik-initiative.github.io/mii-fhir-validator/"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.source="https://github.com/medizininformatik-initiative/mii-fhir-validator"
-
-# Install required tools
-RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
 
 # Create working directory
 WORKDIR /app

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -42,8 +42,9 @@ ARG IG_LIST="-ig de.basisprofil.r4#1.5.4 \
   "
 
 # Pre-build FHIR package cache with MII IGs (downloads packages during build)
-RUN java -Xmx4g -Duser.home="/app/fhir-cache" -jar validator_cli.jar ${IG_LIST} -version 4.0 -tx n/a
-RUN chmod -R a+rX /app/fhir-cache
+RUN java -Xmx4g -Duser.home="/app/fhir-cache" -jar validator_cli.jar ${IG_LIST} -version 4.0 -tx n/a \
+  && rm -rf /app/fhir-cache/.fhir/packages/hl7.fhir.r4.examples* \
+  && chmod -R a+rX /app/fhir-cache
 
 # Create directory for IGs
 RUN mkdir -p /igs

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine AS fetch-validator
+FROM curlimages/curl:8.21.0 AS fetch-validator
 ARG VALIDATOR_VERSION=6.9.11
-RUN wget -O /validator_cli.jar \
-  https://github.com/hapifhir/org.hl7.fhir.core/releases/download/${VALIDATOR_VERSION}/validator_cli.jar
+RUN curl -fsSL -o /tmp/validator_cli.jar \
+  https://github.com/hapifhir/org.hl7.fhir.core/releases/download/${VALIDATOR_VERSION}/validator_cli.JAR
 
 FROM eclipse-temurin:25.0.3_9-jre-ubi10-minimal
 

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -11,6 +11,10 @@ LABEL org.opencontainers.image.url="https://medizininformatik-initiative.github.
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.source="https://github.com/medizininformatik-initiative/mii-fhir-validator"
 
+# Create directory for IGs
+RUN mkdir -p /igs \
+  && chown 10001:10001 /igs
+
 USER 10001:10001
 
 # Create working directory and directory for IGs
@@ -50,9 +54,6 @@ ARG IG_LIST="-ig de.basisprofil.r4#1.5.4 \
 # Pre-build FHIR package cache with MII IGs (downloads packages during build)
 RUN java -Xmx4g -Duser.home="/app/fhir-cache" -jar validator_cli.jar ${IG_LIST} -version 4.0 -tx n/a \
   && chmod -R a+rX /app/fhir-cache
-
-# Create directory for IGs
-RUN mkdir -p /igs
 
 # Expose validator port
 EXPOSE 8080

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -48,7 +48,7 @@ ARG IG_LIST="-ig de.basisprofil.r4#1.5.4 \
   "
 
 # Pre-build FHIR package cache with MII IGs (downloads packages during build)
-RUN java -Xmx4g -Duser.home="/app/fhir-cache" -jar validator_cli.jar ${IG_LIST} -version 4.0 -tx n/a -proxy "10.10.6.12:8080" \
+RUN java -Xmx4g -Duser.home="/app/fhir-cache" -jar validator_cli.jar ${IG_LIST} -version 4.0 -tx n/a \
   && chmod -R a+rX /app/fhir-cache
 
 # Create directory for IGs


### PR DESCRIPTION
**Changes in validator**

- Updated Temurin to v25
- Switched base image to UBI10 Minimal
- Replaced wget with curl – Busybox wget doesn't support HTTP CONNECT tunneling, so it couldn't fetch HTTPS URLs through a proxy
- Set a default non-root user – enables runAsNonRoot without additional configuration
- use more descriptive tags for images